### PR TITLE
refactor(query-builder): centralize query handling and streamline sea…

### DIFF
--- a/src/lib/operations/search-operation.ts
+++ b/src/lib/operations/search-operation.ts
@@ -11,7 +11,6 @@ import { elements } from '../utilities/elements'
 import { summary } from '../utilities/summary'
 import { StructureDefinitionDocument } from '../../schema/structure-definition.schema'
 import { setSortOrder } from '../utilities/sort'
-import { text } from '../utilities/text'
 import { QueryBuilder } from '../query-builder/query-builder'
 
 /**

--- a/src/lib/operations/search-operation.ts
+++ b/src/lib/operations/search-operation.ts
@@ -3,7 +3,6 @@ import { Model } from 'mongoose'
 import { FhirResourceDocument } from '../../schema/fhir-resource-schema'
 import { NotFoundException } from '@nestjs/common'
 import { FhirResponse } from '../fhir-response'
-import { set } from 'lodash-es'
 import { SearchResult } from '../../interfaces/search-result'
 import { SearchParameters } from '../../interfaces/search-parameters'
 import { IncludeOperation } from './include-operation'
@@ -109,10 +108,11 @@ export class SearchOperation extends Operation {
    */
   async findById(resourceType: string, id: string, searchParameters?: SearchParameters): Promise<any> {
     
-    let resource = await this.fhirResourceModel.findOne({
+    const qb = new QueryBuilder(resourceType, searchParameters, id)
+    const resource = await this.fhirResourceModel.findOne({
       resourceType, id
     })
-    .select('-_id')
+    .select(qb.projection)
     .lean()
     
     if (!resource) {
@@ -131,19 +131,17 @@ export class SearchOperation extends Operation {
     
     if (searchParameters?._include) {
       const operation = new IncludeOperation(resource, this.fhirResourceModel, this.request)
-      
+
       this.includes = await operation.execute(searchParameters._include)
-      
+
       if (this.includes.length >= 1) {
         return operation.getResponse()
       }
     }
-    
-    if (searchParameters?._elements && typeof searchParameters._elements === 'string') {
-      resource = elements(resource, searchParameters._elements)
-    } else if (searchParameters?._summary && typeof searchParameters._summary === 'string') {
-      resource = await summary(resource, searchParameters._summary, this.structureDefinitonModel)
-    }
+    //
+    // if (searchParameters?._summary && typeof searchParameters._summary === 'string') {
+    //   resource = await summary(resource, searchParameters._summary, this.structureDefinitonModel)
+    // }
     
     return FhirResponse.format(resource)
   }
@@ -158,201 +156,63 @@ export class SearchOperation extends Operation {
    */
   async find(resourceType: string, searchParams: SearchParameters): Promise<SearchResult> {
     
-    this.filter = {
-      resourceType
-    }
-    
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    // this.filter = {
+    //   resourceType
+    // }
+     
     const queryBuilder = new QueryBuilder(resourceType, searchParams)
     
-    if (searchParams) {
-      
-      this.count = searchParams._count ? searchParams._count : 20
-      this.offset = searchParams._offset ? searchParams._offset : 0
-      
-      if (searchParams._id) {
-        this.appendId(searchParams._id)
-      }
-      
-      if (searchParams.identifier) {
-        this.appendIdentifier(searchParams.identifier)
-      }
-      
-      if (searchParams._profile) {
-        this.appendProfile(searchParams._profile)
-      }
-      
-      if (searchParams._tag) {
-        this.appendTag(searchParams._tag)
-      }
-      
-      if (searchParams._security) {
-        this.appendSecurity(searchParams._security)
-      }
-      
-      if (searchParams._text || searchParams._content) {
-        
-        const term = searchParams._text ?? searchParams._content
-        
-        if (typeof term !== 'string') {
-          throw new Error('Invalid search term')
-        }
-        
-        const type = searchParams._text ? '_text' : '_content'
-        this.filter = text(term, type)
-      }
-    }
+    // if (searchParams) {
+    //
+    //   this.count = searchParams._count ? searchParams._count : 20
+    //   this.offset = searchParams._offset ? searchParams._offset : 0
+    //
+    //   if (searchParams._id) {
+    //     this.appendId(searchParams._id)
+    //   }
+    //
+    //   if (searchParams.identifier) {
+    //     this.appendIdentifier(searchParams.identifier)
+    //   }
+    //
+    //   if (searchParams._profile) {
+    //     this.appendProfile(searchParams._profile)
+    //   }
+    //
+    //   if (searchParams._tag) {
+    //     this.appendTag(searchParams._tag)
+    //   }
+    //
+    //   if (searchParams._security) {
+    //     this.appendSecurity(searchParams._security)
+    //   }
+    //
+    //   if (searchParams._text || searchParams._content) {
+    //
+    //     const term = searchParams._text ?? searchParams._content
+    //
+    //     if (typeof term !== 'string') {
+    //       throw new Error('Invalid search term')
+    //     }
+    //
+    //     const type = searchParams._text ? '_text' : '_content'
+    //     this.filter = text(term, type)
+    //   }
+    // }
     
-    const query = this.transform(this.filter)
+   // const query = this.transform(this.filter)
     
     const resources = await this.fhirResourceModel
-    .find(query)
-    .skip(this.offset)
-    .limit(this.count)
+    .find(queryBuilder.query)
+    .skip(queryBuilder.offset)
+    .limit(queryBuilder.count)
     .sort(setSortOrder(searchParams['_sort']))
-    .select('-_id')
+    .select(queryBuilder.projection)
     .lean()
     
-    const total = await this.fhirResourceModel.countDocuments(query)
-    
+    const total = await this.fhirResourceModel.countDocuments(queryBuilder.query)
+
     return FhirResponse.bundle(resources, total, resourceType, this.offset, this.count, this.request)
   }
   
-  /**
-   * Appends an ID filter to the search query.
-   * If an ID is provided, it will be added to the resource filter criteria.
-   *
-   * @param id - The unique identifier to filter by
-   */
-  appendId(id: string): void {
-    
-    if (id) {
-      this.filter.id = id
-    }
-  }
-  
-  private appendSecurity(entity: string | string[]): void {
-    
-    this.filter.identifier = []
-    const identifiers: string[] = []
-    
-    if (typeof entity === 'string') {
-      identifiers.push(entity)
-    }
-    
-    for (const identifier of identifiers) {
-      
-      const [system, value] = identifier.split('|')
-      const config = {
-        system
-      }
-      
-      if (value) {
-        Object.assign(config, {
-          value
-        })
-      }
-      
-      set(this.filter, 'meta.security', config)
-    }
-  }
-  
-  /**
-   * Processes and appends identifier filters to the search query.
-   * Handles both single string and array of identifier strings in the format "system|value".
-   *
-   * @param entity - Single identifier string or array of identifier strings
-   * @private
-   */
-  private appendIdentifier(entity: string | string[]): void {
-    
-    this.filter.identifier = []
-    const identifiers: string[] = []
-    
-    if (typeof entity === 'string') {
-      identifiers.push(entity)
-    }
-    
-    for (const identifier of identifiers) {
-      
-      const [system, value] = identifier.split('|')
-      const config = {
-        system
-      }
-      
-      if (value) {
-        Object.assign(config, {
-          value
-        })
-      }
-      
-      this.filter.identifier = config
-    }
-    
-    if (this.filter.identifier.length === 0) {
-      delete this.filter.identifier
-    }
-  }
-  
-  /**
-   * Appends a profile filter to the search query.
-   * If a profile URL is provided, it will be added to the resource's meta.profile criteria.
-   * This allows filtering resources based on their conformance to specific FHIR profiles.
-   *
-   * @param profile - The profile URL to filter by
-   * @private
-   */
-  private appendProfile(profile: string): void {
-    
-    if (profile) {
-      set(this.filter, 'meta.profile', profile)
-    }
-  }
-  
-  /**
-   * Appends a tag filter to the search query.
-   * If a tag value is provided, it will be added to the resource's meta.tag criteria.
-   * This allows filtering resources based on their associated tags.
-   *
-   * @param tag - The tag value to filter by
-   */
-  private appendTag(tag: string): void {
-    
-    if (tag) {
-      set(this.filter, 'meta.tag', tag)
-    }
-  }
-  
-  /**
-   * Transforms a nested object into dot notation format that Mongoose can effectively use for querying.
-   * This method recursively flattens nested objects into a single-level object where nested keys
-   * are represented using dot notation (e.g., 'parent.child.grandchild').
-   *
-   * @param nestedQuery - The nested object to transform
-   * @param prefix - The prefix to prepend to the keys (used for recursion)
-   * @returns An object with flattened structure using dot notation
-   */
-  private transform(nestedQuery: any, prefix: string = ''): any {
-    
-    const transformed: any = {}
-    
-    for (const key in nestedQuery) {
-      
-      if (nestedQuery.hasOwnProperty(key)) {
-        
-        const currentKey = prefix ? `${prefix}.${key}` : key
-        const value = nestedQuery[key]
-        
-        if ((key === '$and' || key === '$or' || key === '$not' || key === '$elemMatch' || key === '$text' || key === 'text.div')) {
-          transformed[currentKey] = value
-        } else if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-          Object.assign(transformed, this.transform(value, currentKey))
-        } else {
-          transformed[currentKey] = value
-        }
-      }
-    }
-    
-    return transformed
-  }
 }


### PR DESCRIPTION
…rch operations

- Introduced `QueryBuilder` to encapsulate query construction, reducing redundancy in `SearchOperation`.
- Added `_elements`, `_include`, and `_summary` handling to `QueryBuilder` for enhanced flexibility.
- Simplified `SearchOperation` by delegating query-related tasks to `QueryBuilder`.