### PR TITLE
refactor(fhir-service): remove unused FHIR validation event handling …

### DIFF
--- a/src/events/fhir-event-listener.ts
+++ b/src/events/fhir-event-listener.ts
@@ -38,11 +38,6 @@ export class FhirEventListener {
         this.provenanceBuilder.register(payload, 'delete')
     }
 
-    @OnEvent('fhir.validated')
-    handleFhirValidatedEvent(payload: any): void {
-        console.log('FHIR resource validated:', payload);
-    }
-
     @OnEvent('fhir.read')
     handleFhirReadEvent(payload: any): void {
         this.provenanceBuilder.register(payload, 'read')

--- a/src/schema/fhir-resource-schema.ts
+++ b/src/schema/fhir-resource-schema.ts
@@ -114,12 +114,11 @@ fhirResourceSchema.index({ resourceType: 1, 'patient.reference': 1 }) // Voor En
 
 // Pre-save hook voor meta.lastUpdated en meta.versionId
 fhirResourceSchema.pre('save', function(next) {
-  // Zorg dat id aanwezig is
+
   if (!this.id) {
     this.id = uuidv4()
   }
-  
-  // Meta bijwerken
+
   this.meta = this.meta || {}
   this.meta.lastUpdated = new Date()
   

--- a/src/services/validation/validation.service.ts
+++ b/src/services/validation/validation.service.ts
@@ -1,19 +1,18 @@
-import { Injectable } from '@nestjs/common'
-import { StructureDefinitionDocument, StructureDefinitionSchema } from '../../schema/structure-definition.schema'
-import { Model } from 'mongoose'
-import { InjectModel } from '@nestjs/mongoose'
-import { ValidationWarning } from '../../interfaces/validation-warning'
-import { ValidationResult } from '../../interfaces/validation-result'
-import { ValidationError } from '../../interfaces/validation-error'
-import { StructureDefinition } from '../../interfaces/structure-definition'
-import { ElementDefinition } from '../../interfaces/element-definition'
+import {Injectable} from '@nestjs/common'
+import {StructureDefinitionDocument, StructureDefinitionSchema} from '../../schema/structure-definition.schema'
+import {Model} from 'mongoose'
+import {InjectModel} from '@nestjs/mongoose'
+import {ValidationWarning} from '../../interfaces/validation-warning'
+import {ValidationResult} from '../../interfaces/validation-result'
+import {ValidationError} from '../../interfaces/validation-error'
+import {StructureDefinition} from '../../interfaces/structure-definition'
+import {ElementDefinition} from '../../interfaces/element-definition'
 import * as fhirPath from 'fhirpath'
-import { first } from 'lodash-es'
-import { TerminologyService } from '../terminology/terminology.service'
+import {first} from 'lodash-es'
+import {TerminologyService} from '../terminology/terminology.service'
 import * as fhirModel from 'fhirpath/fhir-context/r4'
-import { ValidateType } from '../../lib/validation/validate-type'
-import { EventEmitter2 } from '@nestjs/event-emitter'
-import { FhirEvent } from '../../events/fhir-event-listener'
+import {ValidateType} from '../../lib/validation/validate-type'
+import {EventEmitter2} from '@nestjs/event-emitter'
 
 /**
  * Service responsible for validating FHIR resources against their structure definitions.
@@ -101,11 +100,6 @@ export class ValidationService {
     
     validationResult.errors.forEach(error => {
       console.log(`  - ${error.path}: ${error.message}`)
-    })
-    
-    this.eventEmitter.emit(FhirEvent.VALIDATED, {
-      resourceType: this.resourceType,
-      validationResult: validationResult
     })
     
     return validationResult


### PR DESCRIPTION
…and cleanup outdated code

- Removed `handleFhirValidatedEvent` method from `FhirEventListener` as it is no longer used.
- Eliminated unnecessary event emission logic in `ValidationService`.
- Minor formatting adjustments for improved readability.