### PR TITLE
feat(security): add JWT token expiration validation in FhirScopeAutho…

### DIFF
--- a/src/lib/authorization/fhir-scope-authorization.ts
+++ b/src/lib/authorization/fhir-scope-authorization.ts
@@ -240,6 +240,12 @@ export class FhirScopeAuthorization {
         if (!token) return;
 
         const decoded = jose.decodeJwt(token);
+        
+        // Validate token expiration
+        if (decoded.exp && decoded.exp < Date.now() / 1000) {
+            return; // Token is expired, don't set scope
+        }
+        
         this._scope = (decoded.scope as string || '').split(' ')
     }
 }


### PR DESCRIPTION
…rization

- Added expiration check in setScope() method to prevent expired tokens from setting scopes
- Token expiration is validated against current timestamp before extracting scopes
- Returns early if token is expired, preventing authorization with invalid tokens

🤖 Generated with [Claude Code](https://claude.ai/code)