### PR TITLE
test(subscription): add comprehensive unit tests for SubscriptionService

### DIFF
--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -1,0 +1,407 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+import configuration from './configuration';
+
+// Mock the fs module
+jest.mock('fs');
+const mockExistsSync = existsSync as jest.MockedFunction<typeof existsSync>;
+const mockReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
+
+// Mock the path module
+jest.mock('path');
+const mockResolve = resolve as jest.MockedFunction<typeof resolve>;
+
+describe('Configuration', () => {
+  const originalProcessEnv = process.env;
+
+  beforeEach(() => {
+    // Reset all mocks
+    jest.clearAllMocks();
+    
+    // Reset process.env
+    process.env = { ...originalProcessEnv };
+    
+    // Default mock implementations
+    mockResolve.mockImplementation((dir: string, file: string) => `${dir}/${file}`);
+  });
+
+  afterAll(() => {
+    // Restore original process.env
+    process.env = originalProcessEnv;
+  });
+
+  describe('successful configuration loading', () => {
+    it('should load configuration for local environment', () => {
+      const mockConfig = {
+        mongodb: {
+          host: 'localhost',
+          port: 27017,
+          database: 'fhir-server'
+        },
+        authorization: {
+          oauth: {
+            enabled: false
+          }
+        }
+      };
+      
+      process.env.ENV_NAME = 'local';
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(mockConfig));
+
+      const result = configuration();
+
+      expect(mockResolve).toHaveBeenCalledWith(expect.any(String), '../../../config/local.json');
+      expect(mockExistsSync).toHaveBeenCalledWith(expect.stringContaining('local.json'));
+      expect(mockReadFileSync).toHaveBeenCalledWith(expect.stringContaining('local.json'), 'utf8');
+      expect(result).toEqual(mockConfig);
+    });
+
+    it('should load configuration for development environment', () => {
+      const mockConfig = {
+        mongodb: {
+          host: 'dev-mongo.example.com',
+          port: 27017,
+          database: 'fhir-dev'
+        },
+        authorization: {
+          oauth: {
+            enabled: true,
+            introspect: 'https://oauth.dev.example.com/introspect'
+          }
+        }
+      };
+      
+      process.env.ENV_NAME = 'dev';
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(mockConfig));
+
+      const result = configuration();
+
+      expect(mockResolve).toHaveBeenCalledWith(expect.any(String), '../../../config/dev.json');
+      expect(mockExistsSync).toHaveBeenCalledWith(expect.stringContaining('dev.json'));
+      expect(result).toEqual(mockConfig);
+    });
+
+    it('should load configuration for production environment', () => {
+      const mockConfig = {
+        mongodb: {
+          host: 'prod-mongo.example.com',
+          port: 27017,
+          database: 'fhir-prod'
+        },
+        authorization: {
+          oauth: {
+            enabled: true,
+            introspect: 'https://oauth.prod.example.com/introspect'
+          }
+        },
+        terminology: {
+          enabled: true,
+          baseUrl: 'https://terminologieserver.nl'
+        }
+      };
+      
+      process.env.ENV_NAME = 'prd';
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(mockConfig));
+
+      const result = configuration();
+
+      expect(mockResolve).toHaveBeenCalledWith(expect.any(String), '../../../config/prd.json');
+      expect(mockExistsSync).toHaveBeenCalledWith(expect.stringContaining('prd.json'));
+      expect(result).toEqual(mockConfig);
+    });
+
+    it('should load configuration for acceptance environment', () => {
+      const mockConfig = {
+        mongodb: {
+          host: 'acc-mongo.example.com',
+          port: 27017,
+          database: 'fhir-acc'
+        }
+      };
+      
+      process.env.ENV_NAME = 'acc';
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(mockConfig));
+
+      const result = configuration();
+
+      expect(mockResolve).toHaveBeenCalledWith(expect.any(String), '../../../config/acc.json');
+      expect(result).toEqual(mockConfig);
+    });
+
+    it('should handle complex nested configuration objects', () => {
+      const complexConfig = {
+        mongodb: {
+          host: 'localhost',
+          port: 27017,
+          database: 'fhir-server',
+          options: {
+            useNewUrlParser: true,
+            useUnifiedTopology: true,
+            maxPoolSize: 10
+          }
+        },
+        authorization: {
+          oauth: {
+            enabled: true,
+            introspect: 'https://oauth.example.com/introspect',
+            scopes: ['read', 'write', 'admin']
+          },
+          smartOnFhir: {
+            enabled: true,
+            clientId: 'test-client',
+            redirectUri: 'http://localhost:3000/callback'
+          }
+        },
+        cron: {
+          metrics: { enabled: true, interval: '*/5 * * * *' },
+          backup: { enabled: false, directory: './export' }
+        }
+      };
+      
+      process.env.ENV_NAME = 'local';
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(complexConfig));
+
+      const result = configuration();
+
+      expect(result).toEqual(complexConfig);
+    });
+
+    it('should handle empty configuration object', () => {
+      const emptyConfig = {};
+      
+      process.env.ENV_NAME = 'test';
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(emptyConfig));
+
+      const result = configuration();
+
+      expect(result).toEqual(emptyConfig);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw HttpException when config file does not exist', () => {
+      process.env.ENV_NAME = 'nonexistent';
+      mockExistsSync.mockReturnValue(false);
+      mockResolve.mockReturnValue('/path/to/config/nonexistent.json');
+
+      expect(() => configuration()).toThrow(HttpException);
+      expect(() => configuration()).toThrow('Config file /path/to/config/nonexistent.json not found');
+      
+      try {
+        configuration();
+        fail('Expected HttpException to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(HttpException);
+        expect(error.getStatus()).toBe(HttpStatus.NOT_FOUND);
+        expect(error.message).toBe('Config file /path/to/config/nonexistent.json not found');
+        // The HttpException constructor's third parameter is options, not cause
+        // We can't easily test the internal options object, so we'll skip this assertion
+      }
+    });
+
+    it('should throw HttpException with correct file path for missing dev config', () => {
+      process.env.ENV_NAME = 'dev';
+      mockExistsSync.mockReturnValue(false);
+      mockResolve.mockReturnValue('/app/config/dev.json');
+
+      expect(() => configuration()).toThrow('Config file /app/config/dev.json not found');
+    });
+
+    it('should throw HttpException with correct file path for missing prod config', () => {
+      process.env.ENV_NAME = 'prd';
+      mockExistsSync.mockReturnValue(false);
+      mockResolve.mockReturnValue('/app/config/prd.json');
+
+      expect(() => configuration()).toThrow('Config file /app/config/prd.json not found');
+    });
+
+    it('should handle undefined ENV_NAME gracefully', () => {
+      delete process.env.ENV_NAME;
+      mockExistsSync.mockReturnValue(false);
+      mockResolve.mockReturnValue('/path/to/config/undefined.json');
+
+      expect(() => configuration()).toThrow(HttpException);
+      expect(mockResolve).toHaveBeenCalledWith(expect.any(String), '../../../config/undefined.json');
+    });
+
+    it('should handle empty ENV_NAME gracefully', () => {
+      process.env.ENV_NAME = '';
+      mockExistsSync.mockReturnValue(false);
+      mockResolve.mockReturnValue('/path/to/config/.json');
+
+      expect(() => configuration()).toThrow(HttpException);
+      expect(mockResolve).toHaveBeenCalledWith(expect.any(String), '../../../config/.json');
+    });
+  });
+
+  describe('JSON parsing', () => {
+    it('should handle malformed JSON gracefully', () => {
+      process.env.ENV_NAME = 'local';
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue('{ invalid json }');
+
+      expect(() => configuration()).toThrow();
+    });
+
+    it('should parse JSON with whitespace and formatting', () => {
+      const configWithWhitespace = `
+      {
+        "mongodb": {
+          "host": "localhost",
+          "port": 27017
+        }
+      }
+      `;
+      const expectedConfig = {
+        mongodb: {
+          host: 'localhost',
+          port: 27017
+        }
+      };
+      
+      process.env.ENV_NAME = 'local';
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(configWithWhitespace);
+
+      const result = configuration();
+
+      expect(result).toEqual(expectedConfig);
+    });
+
+    it('should handle JSON with various data types', () => {
+      const configWithTypes = {
+        stringValue: 'test',
+        numberValue: 123,
+        booleanValue: true,
+        nullValue: null,
+        arrayValue: [1, 2, 3],
+        objectValue: { nested: 'value' }
+      };
+      
+      process.env.ENV_NAME = 'local';
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(configWithTypes));
+
+      const result = configuration();
+
+      expect(result).toEqual(configWithTypes);
+    });
+  });
+
+  describe('file system operations', () => {
+    it('should use correct path resolution', () => {
+      process.env.ENV_NAME = 'local';
+      mockExistsSync.mockReturnValue(false);
+      
+      // Mock __dirname to a specific value for testing
+      mockResolve.mockImplementation((dirname, relativePath) => {
+        if (dirname.includes('src/config') && relativePath === '../../../config/local.json') {
+          return '/app/config/local.json';
+        }
+
+        return `${dirname}/${relativePath}`;
+      });
+
+      expect(() => configuration()).toThrow();
+      expect(mockResolve).toHaveBeenCalledWith(expect.any(String), '../../../config/local.json');
+    });
+
+    it('should handle file read with utf8 encoding', () => {
+      const mockConfig = { test: 'value' };
+      
+      process.env.ENV_NAME = 'local';
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(mockConfig));
+
+      configuration();
+
+      expect(mockReadFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        'utf8'
+      );
+    });
+
+    it('should call toString() on file contents', () => {
+      const mockConfig = { test: 'value' };
+      const mockBuffer = {
+        toString: jest.fn().mockReturnValue(JSON.stringify(mockConfig))
+      };
+      
+      process.env.ENV_NAME = 'local';
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(mockBuffer as any);
+
+      const result = configuration();
+
+      expect(mockBuffer.toString).toHaveBeenCalled();
+      expect(result).toEqual(mockConfig);
+    });
+  });
+
+  describe('environment variations', () => {
+    const environments = ['local', 'dev', 'acc', 'prd'];
+
+    environments.forEach(env => {
+      it(`should load configuration for ${env} environment`, () => {
+        const mockConfig = { environment: env, test: true };
+        
+        process.env.ENV_NAME = env;
+        mockExistsSync.mockReturnValue(true);
+        mockReadFileSync.mockReturnValue(JSON.stringify(mockConfig));
+
+        const result = configuration();
+
+        expect(mockResolve).toHaveBeenCalledWith(expect.any(String), `../../../config/${env}.json`);
+        expect(result).toEqual(mockConfig);
+      });
+    });
+
+    it('should handle custom environment names', () => {
+      const customEnv = 'staging';
+      const mockConfig = { environment: customEnv };
+      
+      process.env.ENV_NAME = customEnv;
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(mockConfig));
+
+      const result = configuration();
+
+      expect(mockResolve).toHaveBeenCalledWith(expect.any(String), `../../../config/${customEnv}.json`);
+      expect(result).toEqual(mockConfig);
+    });
+  });
+
+  describe('webpack compatibility', () => {
+    it('should handle webpack build directory structure', () => {
+      // The comment in the original code mentions webpack changes the relative directory
+      process.env.ENV_NAME = 'local';
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue('{}');
+
+      configuration();
+
+      // Verify it uses the documented webpack-compatible path
+      expect(mockResolve).toHaveBeenCalledWith(expect.any(String), '../../../config/local.json');
+    });
+
+    it('should resolve paths relative to __dirname correctly', () => {
+      process.env.ENV_NAME = 'test';
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue('{}');
+
+      configuration();
+
+      // Ensure resolve is called with __dirname as first parameter
+      expect(mockResolve).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('config/test.json'));
+      const resolveCall = mockResolve.mock.calls[0];
+      expect(resolveCall[0]).toMatch(/src[\\/]config/);
+    });
+  });
+});

--- a/src/events/subscription-event-listener.spec.ts
+++ b/src/events/subscription-event-listener.spec.ts
@@ -195,11 +195,11 @@ describe('SubscriptionEventListener', () => {
     });
   });
 
-  describe('handleResourcDeletedEvent', () => {
+  describe('handleResourceDeletedEvent', () => {
     it('should handle resource deleted event', () => {
       const payload = ResourceEvent.DELETED;
 
-      listener.handleResourcDeletedEvent(payload);
+      listener.handleResourceDeletedEvent(payload);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(payload);
       expect(mockConsoleLog).toHaveBeenCalledTimes(1);
@@ -217,7 +217,7 @@ describe('SubscriptionEventListener', () => {
         timestamp: '2023-08-27T10:00:00Z'
       };
 
-      listener.handleResourcDeletedEvent(deletePayload as any);
+      listener.handleResourceDeletedEvent(deletePayload as any);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(deletePayload);
     });
@@ -230,7 +230,7 @@ describe('SubscriptionEventListener', () => {
       ];
 
       cascadingDeletes.forEach(deleteEvent => {
-        listener.handleResourcDeletedEvent(deleteEvent as any);
+        listener.handleResourceDeletedEvent(deleteEvent as any);
       });
 
       expect(mockConsoleLog).toHaveBeenCalledTimes(3);
@@ -254,8 +254,8 @@ describe('SubscriptionEventListener', () => {
         status: 'removed'
       };
 
-      listener.handleResourcDeletedEvent(softDelete as any);
-      listener.handleResourcDeletedEvent(hardDelete as any);
+      listener.handleResourceDeletedEvent(softDelete as any);
+      listener.handleResourceDeletedEvent(hardDelete as any);
 
       expect(mockConsoleLog).toHaveBeenCalledTimes(2);
       expect(mockConsoleLog).toHaveBeenNthCalledWith(1, softDelete);
@@ -275,7 +275,7 @@ describe('SubscriptionEventListener', () => {
         criteria: 'status=inactive AND lastModified<2023-01-01'
       };
 
-      listener.handleResourcDeletedEvent(bulkDeletePayload as any);
+      listener.handleResourceDeletedEvent(bulkDeletePayload as any);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(bulkDeletePayload);
     });
@@ -285,13 +285,13 @@ describe('SubscriptionEventListener', () => {
     it('should have correctly named event handler methods', () => {
       expect(typeof listener.handleResourceCreatedEvent).toBe('function');
       expect(typeof listener.handleResourceUpdatedEvent).toBe('function');
-      expect(typeof listener.handleResourcDeletedEvent).toBe('function');
+      expect(typeof listener.handleResourceDeletedEvent).toBe('function');
     });
 
-    it('should have the typo in handleResourcDeletedEvent method name', () => {
+    it('should have the typo in handleResourceDeletedEvent method name', () => {
       // This test documents the existing typo - should be "Resource" not "Resourc"
-      expect(listener.handleResourcDeletedEvent).toBeDefined();
-      expect(typeof listener.handleResourcDeletedEvent).toBe('function');
+      expect(listener.handleResourceDeletedEvent).toBeDefined();
+      expect(typeof listener.handleResourceDeletedEvent).toBe('function');
     });
 
     it('should accept any parameter type for event handlers', () => {
@@ -299,7 +299,7 @@ describe('SubscriptionEventListener', () => {
       // but actually receives event data, these should not throw
       expect(() => listener.handleResourceCreatedEvent('test' as any)).not.toThrow();
       expect(() => listener.handleResourceUpdatedEvent({ data: 'test' } as any)).not.toThrow();
-      expect(() => listener.handleResourcDeletedEvent(123 as any)).not.toThrow();
+      expect(() => listener.handleResourceDeletedEvent(123 as any)).not.toThrow();
     });
   });
 
@@ -323,7 +323,7 @@ describe('SubscriptionEventListener', () => {
       const events = [
         { handler: 'handleResourceCreatedEvent', payload: ResourceEvent.CREATED },
         { handler: 'handleResourceUpdatedEvent', payload: ResourceEvent.UPDATED },
-        { handler: 'handleResourcDeletedEvent', payload: ResourceEvent.DELETED }
+        { handler: 'handleResourceDeletedEvent', payload: ResourceEvent.DELETED }
       ];
 
       const iterations = 100;
@@ -370,7 +370,7 @@ describe('SubscriptionEventListener', () => {
     it('should handle null and undefined payloads without errors', () => {
       expect(() => listener.handleResourceCreatedEvent(null as any)).not.toThrow();
       expect(() => listener.handleResourceUpdatedEvent(undefined as any)).not.toThrow();
-      expect(() => listener.handleResourcDeletedEvent(null as any)).not.toThrow();
+      expect(() => listener.handleResourceDeletedEvent(null as any)).not.toThrow();
 
       expect(mockConsoleLog).toHaveBeenCalledTimes(3);
       expect(mockConsoleLog).toHaveBeenNthCalledWith(1, null);
@@ -415,7 +415,7 @@ describe('SubscriptionEventListener', () => {
         }
       };
 
-      expect(() => listener.handleResourcDeletedEvent(specialPayload as any)).not.toThrow();
+      expect(() => listener.handleResourceDeletedEvent(specialPayload as any)).not.toThrow();
       expect(mockConsoleLog).toHaveBeenCalledWith(specialPayload);
     });
 
@@ -482,7 +482,7 @@ describe('SubscriptionEventListener', () => {
         timestamp: new Date().toISOString()
       };
 
-      listener.handleResourcDeletedEvent(deleteEvent as any);
+      listener.handleResourceDeletedEvent(deleteEvent as any);
 
       // Verify all events were processed
       expect(mockConsoleLog).toHaveBeenCalledTimes(4);
@@ -546,7 +546,7 @@ describe('SubscriptionEventListener', () => {
     it('should log exact payload for deleted events', () => {
       const testPayload = { test: 'deleted-payload', date: new Date().toISOString() };
 
-      listener.handleResourcDeletedEvent(testPayload as any);
+      listener.handleResourceDeletedEvent(testPayload as any);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(testPayload);
       expect(mockConsoleLog).toHaveBeenCalledTimes(1);

--- a/src/events/subscription-event-listener.ts
+++ b/src/events/subscription-event-listener.ts
@@ -21,7 +21,7 @@ export class SubscriptionEventListener {
     }
 
     @OnEvent('resource.deleted')
-    handleResourcDeletedEvent(payload: ResourceEvent): void {
+    handleResourceDeletedEvent(payload: ResourceEvent): void {
         console.log(payload)
     }
 }

--- a/src/services/subscription/subscription.service.spec.ts
+++ b/src/services/subscription/subscription.service.spec.ts
@@ -1,0 +1,527 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SubscriptionService } from './subscription.service';
+import { getModelToken } from '@nestjs/mongoose';
+import { SubscriptionSchema, SubscriptionDocument, SubscriptionStatus, SubscriptionChannelType } from '../../schema/subscription-schema';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { CreateSubscriptionDto } from '../../dto/create-subscription-dto';
+import { UpdateSubscriptionDto } from '../../dto/update-subscription-dto';
+import { ResourceChangeEvent } from '../../interfaces/resource-change-event';
+import { Types } from 'mongoose';
+import axios from 'axios';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('SubscriptionService', () => {
+  let service: SubscriptionService;
+  let mockSubscriptionModel: any;
+  let mockEventEmitter: jest.Mocked<EventEmitter2>;
+
+  const mockSubscriptionId = '507f1f77bcf86cd799439011';
+  
+  const mockSubscription = {
+    _id: new Types.ObjectId(mockSubscriptionId),
+    resourceType: 'Subscription',
+    status: SubscriptionStatus.ACTIVE,
+    criteria: 'Patient?active=true',
+    channel: {
+      type: SubscriptionChannelType.REST_HOOK,
+      endpoint: 'https://example.com/webhook',
+      payload: 'application/fhir+json'
+    },
+    reason: 'Test subscription',
+    errorCount: 0,
+    lastError: undefined,
+    lastNotification: undefined,
+    lastSuccessfulNotification: undefined,
+    meta: {
+      versionId: '1',
+      lastUpdated: new Date()
+    },
+    id: mockSubscriptionId,
+    save: jest.fn()
+  };
+
+  const mockCreateDto: CreateSubscriptionDto = {
+    resourceType: 'Subscription',
+    status: SubscriptionStatus.REQUESTED,
+    criteria: 'Patient?active=true',
+    channel: {
+      type: SubscriptionChannelType.REST_HOOK,
+      endpoint: 'https://example.com/webhook',
+      payload: 'application/fhir+json'
+    },
+    reason: 'Test subscription'
+  };
+
+  beforeEach(async () => {
+    mockSubscriptionModel = jest.fn().mockImplementation((data) => ({
+      ...mockSubscription,
+      ...data,
+      save: jest.fn().mockResolvedValue({ ...mockSubscription, ...data })
+    }));
+    
+    mockSubscriptionModel.find = jest.fn().mockReturnValue({
+      exec: jest.fn().mockResolvedValue([mockSubscription])
+    });
+    mockSubscriptionModel.findById = jest.fn().mockReturnValue({
+      exec: jest.fn().mockResolvedValue(mockSubscription)
+    });
+    mockSubscriptionModel.findByIdAndDelete = jest.fn().mockReturnValue({
+      exec: jest.fn().mockResolvedValue(mockSubscription)
+    });
+
+    mockEventEmitter = {
+      on: jest.fn(),
+      emit: jest.fn(),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SubscriptionService,
+        {
+          provide: getModelToken(SubscriptionSchema.name),
+          useValue: mockSubscriptionModel,
+        },
+        {
+          provide: EventEmitter2,
+          useValue: mockEventEmitter,
+        },
+      ],
+    }).compile();
+
+    service = module.get<SubscriptionService>(SubscriptionService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should register event listener on instantiation', () => {
+    expect(mockEventEmitter.on).toHaveBeenCalledWith('resource.changed', expect.any(Function));
+  });
+
+  describe('create', () => {
+    it('should create a subscription successfully', async () => {
+      const result = await service.create(mockCreateDto);
+
+      expect(mockSubscriptionModel).toHaveBeenCalledWith({
+        ...mockCreateDto,
+        end: undefined,
+        meta: {
+          versionId: '1',
+          lastUpdated: expect.any(Date)
+        }
+      });
+      expect(result).toBeDefined();
+    });
+
+    it('should create subscription with end date', async () => {
+      const dtoWithEndDate = { ...mockCreateDto, end: '2025-12-31T23:59:59Z' };
+
+      await service.create(dtoWithEndDate);
+
+      expect(mockSubscriptionModel).toHaveBeenCalledWith({
+        ...dtoWithEndDate,
+        end: new Date('2025-12-31T23:59:59Z'),
+        meta: {
+          versionId: '1',
+          lastUpdated: expect.any(Date)
+        }
+      });
+    });
+
+    it('should activate subscription when status is REQUESTED', async () => {
+      const requestedDto = { ...mockCreateDto, status: SubscriptionStatus.REQUESTED };
+      const mockInstanceWithStatus = {
+        ...mockSubscription,
+        status: SubscriptionStatus.REQUESTED,
+        _id: mockSubscriptionId,
+        save: jest.fn().mockResolvedValue({ ...mockSubscription, status: SubscriptionStatus.REQUESTED })
+      };
+      
+      mockSubscriptionModel.mockReturnValue(mockInstanceWithStatus);
+      const activateSpy = jest.spyOn(service, 'activateSubscription').mockResolvedValue(mockSubscription as unknown as SubscriptionDocument);
+
+      await service.create(requestedDto);
+
+      expect(activateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw BadRequestException for invalid criteria', async () => {
+      const invalidDto = { ...mockCreateDto, criteria: '' };
+
+      await expect(service.create(invalidDto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException for unsupported resource type', async () => {
+      const invalidDto = { ...mockCreateDto, criteria: 'UnsupportedResource?param=value' };
+
+      await expect(service.create(invalidDto)).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all subscriptions with default filter', async () => {
+      const result = await service.findAll();
+
+      expect(result).toEqual([mockSubscription]);
+      expect(mockSubscriptionModel.find).toHaveBeenCalledWith({});
+    });
+
+    it('should return filtered subscriptions', async () => {
+      const filter = { status: SubscriptionStatus.ACTIVE };
+      
+      const result = await service.findAll(filter);
+
+      expect(result).toEqual([mockSubscription]);
+      expect(mockSubscriptionModel.find).toHaveBeenCalledWith(filter);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return subscription by valid ID', async () => {
+      const result = await service.findOne(mockSubscriptionId);
+
+      expect(result).toEqual(mockSubscription);
+      expect(mockSubscriptionModel.findById).toHaveBeenCalledWith(mockSubscriptionId);
+    });
+
+    it('should throw BadRequestException for invalid ID', async () => {
+      const invalidId = 'invalid-id';
+
+      await expect(service.findOne(invalidId)).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw NotFoundException when subscription not found', async () => {
+      mockSubscriptionModel.findById.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null)
+      });
+
+      await expect(service.findOne(mockSubscriptionId)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('should update subscription successfully', async () => {
+      const updateDto: UpdateSubscriptionDto = { status: SubscriptionStatus.OFF };
+      const mockUpdatedSub = { ...mockSubscription, status: SubscriptionStatus.OFF, save: jest.fn().mockResolvedValue(mockSubscription) };
+      
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockUpdatedSub as unknown as SubscriptionDocument);
+
+      const result = await service.update(mockSubscriptionId, updateDto);
+
+      expect(result).toBeDefined();
+    });
+
+    it('should update subscription with end date', async () => {
+      const updateDto: UpdateSubscriptionDto = { end: '2025-12-31T23:59:59Z' };
+      const mockSub = { ...mockSubscription, end: new Date(), save: jest.fn().mockResolvedValue(mockSubscription) };
+      
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockSub as unknown as SubscriptionDocument);
+
+      await service.update(mockSubscriptionId, updateDto);
+
+      expect(mockSub.end).toEqual(new Date('2025-12-31T23:59:59Z'));
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete subscription successfully', async () => {
+      await service.delete(mockSubscriptionId);
+
+      expect(mockSubscriptionModel.findByIdAndDelete).toHaveBeenCalledWith(mockSubscriptionId);
+    });
+
+    it('should throw NotFoundException when subscription not found', async () => {
+      mockSubscriptionModel.findByIdAndDelete.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null)
+      });
+
+      await expect(service.delete(mockSubscriptionId)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('activateSubscription', () => {
+    it('should activate REST hook subscription successfully', async () => {
+      const restHookSubscription = {
+        ...mockSubscription,
+        channel: { type: SubscriptionChannelType.REST_HOOK, endpoint: 'https://example.com/webhook' },
+        save: jest.fn().mockResolvedValue(mockSubscription)
+      };
+      
+      jest.spyOn(service, 'findOne').mockResolvedValue(restHookSubscription as unknown as SubscriptionDocument);
+      jest.spyOn(service as any, 'testEndpoint').mockResolvedValue(undefined);
+
+      await service.activateSubscription(mockSubscriptionId);
+
+      expect(restHookSubscription.status).toBe(SubscriptionStatus.ACTIVE);
+      expect(restHookSubscription.errorCount).toBe(0);
+      expect(restHookSubscription.lastError).toBeUndefined();
+    });
+
+    it('should activate non-REST hook subscription without testing endpoint', async () => {
+      const websocketSubscription = {
+        ...mockSubscription,
+        channel: { type: SubscriptionChannelType.WEBSOCKET },
+        save: jest.fn().mockResolvedValue(mockSubscription)
+      };
+      
+      jest.spyOn(service, 'findOne').mockResolvedValue(websocketSubscription as unknown as SubscriptionDocument);
+
+      await service.activateSubscription(mockSubscriptionId);
+
+      expect(websocketSubscription.status).toBe(SubscriptionStatus.ACTIVE);
+    });
+  });
+
+  describe('deactivateSubscription', () => {
+    it('should deactivate subscription successfully', async () => {
+      const mockSub = { ...mockSubscription, save: jest.fn().mockResolvedValue(mockSubscription) };
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockSub as unknown as SubscriptionDocument);
+
+      await service.deactivateSubscription(mockSubscriptionId);
+
+      expect(mockSub.status).toBe(SubscriptionStatus.OFF);
+    });
+  });
+
+  describe('findActiveSubscriptionsForResource', () => {
+    it('should find active subscriptions for resource type', async () => {
+      const result = await service.findActiveSubscriptionsForResource('Patient');
+
+      expect(result).toEqual([mockSubscription]);
+      expect(mockSubscriptionModel.find).toHaveBeenCalledWith({
+        status: SubscriptionStatus.ACTIVE,
+        criteria: new RegExp('^Patient', 'i'),
+        $or: [
+          { end: { $exists: false } },
+          { end: { $gt: expect.any(Date) } }
+        ]
+      });
+    });
+  });
+
+  describe('handleResourceChange', () => {
+    it('should handle resource change event and send notifications', async () => {
+      const event: ResourceChangeEvent = {
+        eventType: 'create',
+        resourceType: 'Patient',
+        resourceId: '123',
+        resource: { resourceType: 'Patient', id: '123' }
+      };
+      
+      jest.spyOn(service, 'findActiveSubscriptionsForResource').mockResolvedValue([mockSubscription as unknown as SubscriptionDocument]);
+      jest.spyOn(service as any, 'matchesCriteria').mockReturnValue(true);
+      jest.spyOn(service as any, 'sendNotification').mockResolvedValue(undefined);
+
+      await (service as any).handleResourceChange(event);
+
+      expect(service.findActiveSubscriptionsForResource).toHaveBeenCalledWith('Patient');
+      expect((service as any).sendNotification).toHaveBeenCalledWith(mockSubscription, event);
+    });
+
+    it('should filter out subscriptions that do not match criteria', async () => {
+      const event: ResourceChangeEvent = {
+        eventType: 'create',
+        resourceType: 'Patient',
+        resourceId: '123'
+      };
+      
+      jest.spyOn(service, 'findActiveSubscriptionsForResource').mockResolvedValue([mockSubscription as unknown as SubscriptionDocument]);
+      jest.spyOn(service as any, 'matchesCriteria').mockReturnValue(false);
+      jest.spyOn(service as any, 'sendNotification').mockResolvedValue(undefined);
+
+      await (service as any).handleResourceChange(event);
+
+      expect((service as any).sendNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('matchesCriteria', () => {
+    it('should return true for matching resource type', () => {
+      const event: ResourceChangeEvent = { eventType: 'create', resourceType: 'Patient', resourceId: '123' };
+      const criteria = 'Patient?active=true';
+
+      const result = (service as any).matchesCriteria(event, criteria);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for non-matching resource type', () => {
+      const event: ResourceChangeEvent = { eventType: 'create', resourceType: 'Observation', resourceId: '123' };
+      const criteria = 'Patient?active=true';
+
+      const result = (service as any).matchesCriteria(event, criteria);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('sendNotification', () => {
+    it('should send REST hook notification successfully', async () => {
+      const restHookSubscription = {
+        ...mockSubscription,
+        channel: { type: SubscriptionChannelType.REST_HOOK, endpoint: 'https://example.com/webhook' },
+        save: jest.fn().mockResolvedValue(mockSubscription)
+      };
+      const event: ResourceChangeEvent = { eventType: 'create', resourceType: 'Patient', resourceId: '123' };
+      
+      jest.spyOn(service as any, 'sendRestHookNotification').mockResolvedValue(undefined);
+
+      await (service as any).sendNotification(restHookSubscription, event);
+
+      expect(restHookSubscription.lastNotification).toBeDefined();
+      expect(restHookSubscription.lastSuccessfulNotification).toBeDefined();
+      expect(restHookSubscription.errorCount).toBe(0);
+    });
+
+    it('should send WebSocket notification successfully', async () => {
+      const websocketSubscription = {
+        ...mockSubscription,
+        channel: { type: SubscriptionChannelType.WEBSOCKET },
+        save: jest.fn().mockResolvedValue(mockSubscription)
+      };
+      const event: ResourceChangeEvent = { eventType: 'create', resourceType: 'Patient', resourceId: '123' };
+
+      await (service as any).sendNotification(websocketSubscription, event);
+
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith('websocket.notification', expect.any(Object));
+      expect(websocketSubscription.lastNotification).toBeDefined();
+    });
+
+    it('should send email notification successfully', async () => {
+      const emailSubscription = {
+        ...mockSubscription,
+        channel: { type: SubscriptionChannelType.EMAIL, endpoint: 'test@example.com' },
+        save: jest.fn().mockResolvedValue(mockSubscription)
+      };
+      const event: ResourceChangeEvent = { eventType: 'create', resourceType: 'Patient', resourceId: '123' };
+
+      await (service as any).sendNotification(emailSubscription, event);
+
+      expect(emailSubscription.lastNotification).toBeDefined();
+    });
+
+    it('should handle notification error', async () => {
+      const subscription = { ...mockSubscription, save: jest.fn() };
+      const event: ResourceChangeEvent = { eventType: 'create', resourceType: 'Patient', resourceId: '123' };
+      const error = new Error('Network error');
+      
+      jest.spyOn(service as any, 'sendRestHookNotification').mockRejectedValue(error);
+      jest.spyOn(service as any, 'handleNotificationError').mockResolvedValue(undefined);
+
+      await (service as any).sendNotification(subscription, event);
+
+      expect((service as any).handleNotificationError).toHaveBeenCalledWith(subscription, error);
+    });
+  });
+
+  describe('createNotificationBundle', () => {
+    it('should create notification bundle with resource', () => {
+      const event: ResourceChangeEvent = {
+        eventType: 'create',
+        resourceType: 'Patient',
+        resourceId: '123',
+        resource: { resourceType: 'Patient', id: '123', name: [{ family: 'Doe' }] }
+      };
+
+      const bundle = (service as any).createNotificationBundle(mockSubscription, event);
+
+      expect(bundle.resourceType).toBe('Bundle');
+      expect(bundle.type).toBe('history');
+      expect(bundle.entry).toHaveLength(2);
+      expect(bundle.entry[0].resource.resourceType).toBe('SubscriptionStatus');
+      expect(bundle.entry[1].resource).toEqual(event.resource);
+    });
+
+    it('should create notification bundle without resource', () => {
+      const event: ResourceChangeEvent = {
+        eventType: 'create',
+        resourceType: 'Patient',
+        resourceId: '123'
+      };
+
+      const bundle = (service as any).createNotificationBundle(mockSubscription, event);
+
+      expect(bundle.resourceType).toBe('Bundle');
+      expect(bundle.entry).toHaveLength(1);
+      expect(bundle.entry[0].resource.resourceType).toBe('SubscriptionStatus');
+    });
+  });
+
+  describe('testEndpoint', () => {
+    it('should test endpoint successfully', async () => {
+      const subscription = {
+        ...mockSubscription,
+        channel: {
+          type: SubscriptionChannelType.REST_HOOK,
+          endpoint: 'https://example.com/webhook',
+          payload: 'application/fhir+json',
+          header: { 'Authorization': 'Bearer token' }
+        }
+      };
+
+      mockedAxios.request.mockResolvedValue({ status: 200 });
+
+      await (service as any).testEndpoint(subscription);
+
+      expect(mockedAxios.request).toHaveBeenCalledWith(expect.objectContaining({
+        method: 'post',
+        url: 'https://example.com/webhook',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/fhir+json'
+        }),
+        data: expect.objectContaining({
+          resourceType: 'Bundle',
+          id: 'test-notification'
+        })
+      }));
+    });
+  });
+
+  describe('handleNotificationError', () => {
+    it('should increment error count and save error message', async () => {
+      const subscription = { ...mockSubscription, errorCount: 0, save: jest.fn().mockResolvedValue(mockSubscription) };
+      const error = new Error('Network timeout');
+
+      await (service as any).handleNotificationError(subscription, error);
+
+      expect(subscription.errorCount).toBe(1);
+      expect(subscription.lastError).toBe('Network timeout');
+      expect(subscription.save).toHaveBeenCalled();
+    });
+
+    it('should deactivate subscription after 5 errors', async () => {
+      const subscription = { ...mockSubscription, errorCount: 4, save: jest.fn().mockResolvedValue(mockSubscription) };
+      const error = new Error('Network timeout');
+
+      await (service as any).handleNotificationError(subscription, error);
+
+      expect(subscription.errorCount).toBe(5);
+      expect(subscription.status).toBe(SubscriptionStatus.ERROR);
+    });
+  });
+
+  describe('validateCriteria', () => {
+    it('should validate correct criteria', () => {
+      expect(() => (service as any).validateCriteria('Patient?active=true')).not.toThrow();
+      expect(() => (service as any).validateCriteria('Observation?status=final')).not.toThrow();
+    });
+
+    it('should throw error for invalid criteria format', () => {
+      expect(() => (service as any).validateCriteria('')).toThrow(BadRequestException);
+      expect(() => (service as any).validateCriteria(null)).toThrow(BadRequestException);
+      expect(() => (service as any).validateCriteria(123 as any)).toThrow(BadRequestException);
+    });
+
+    it('should throw error for unsupported resource type', () => {
+      expect(() => (service as any).validateCriteria('UnsupportedResource?param=value')).toThrow(BadRequestException);
+    });
+  });
+});


### PR DESCRIPTION
- Add 36 comprehensive unit tests covering all SubscriptionService methods
- Test CRUD operations: create, findAll, findOne, update, delete
- Test subscription lifecycle: activation, deactivation, status management
- Test notification system: REST hooks, WebSocket, email notifications
- Test event handling: resource change events, criteria matching
- Test error handling: validation errors, network failures, auto-deactivation
- Test edge cases: invalid IDs, unsupported resource types, missing data
- Mock all dependencies: Mongoose models, EventEmitter2, axios
- Follow existing test patterns and NestJS testing conventions
- All tests pass with proper TypeScript support and ESLint compliance

Additionally fix typo in SubscriptionEventListener method name:
- Rename handleResourcDeletedEvent to handleResourceDeletedEvent
- Update all test references to use correct method name

🤖 Generated with [Claude Code](https://claude.ai/code)