### PR TITLE
Add FHIR-compliant exception handling for ForbiddenException

### DIFF
--- a/src/filters/fhir-forbidden-exception.filter.spec.ts
+++ b/src/filters/fhir-forbidden-exception.filter.spec.ts
@@ -1,0 +1,65 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
+import { FhirForbiddenExceptionFilter } from './fhir-forbidden-exception.filter';
+import { ArgumentsHost } from '@nestjs/common';
+
+describe('FhirForbiddenExceptionFilter', () => {
+    let filter: FhirForbiddenExceptionFilter;
+    let mockResponse: any;
+    let mockHost: ArgumentsHost;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [FhirForbiddenExceptionFilter],
+        }).compile();
+
+        filter = module.get<FhirForbiddenExceptionFilter>(FhirForbiddenExceptionFilter);
+        
+        mockResponse = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn().mockReturnThis()
+        };
+        
+        mockHost = {
+            switchToHttp: jest.fn().mockReturnValue({
+                getResponse: jest.fn().mockReturnValue(mockResponse)
+            })
+        } as any;
+    });
+
+    it('should be defined', () => {
+        expect(filter).toBeDefined();
+    });
+
+    it('should return FHIR OperationOutcome for ForbiddenException', () => {
+        const exception = new ForbiddenException('Access denied');
+        
+        filter.catch(exception, mockHost);
+        
+        expect(mockResponse.status).toHaveBeenCalledWith(403);
+        expect(mockResponse.json).toHaveBeenCalledWith({
+            resourceType: 'OperationOutcome',
+            issue: [{
+                severity: 'error',
+                code: 'forbidden',
+                details: { text: 'Access denied' }
+            }]
+        });
+    });
+
+    it('should handle security violation messages', () => {
+        const exception = new ForbiddenException('Suspicious content detected');
+        
+        filter.catch(exception, mockHost);
+        
+        expect(mockResponse.status).toHaveBeenCalledWith(403);
+        expect(mockResponse.json).toHaveBeenCalledWith({
+            resourceType: 'OperationOutcome',
+            issue: [{
+                severity: 'error',
+                code: 'forbidden',
+                details: { text: 'Suspicious content detected' }
+            }]
+        });
+    });
+});

--- a/src/filters/fhir-forbidden-exception.filter.ts
+++ b/src/filters/fhir-forbidden-exception.filter.ts
@@ -1,0 +1,27 @@
+import { ExceptionFilter, Catch, ArgumentsHost, ForbiddenException } from '@nestjs/common';
+import { Response } from 'express';
+import { FhirResponse } from '../lib/fhir-response';
+
+/**
+ * Exception filter that catches ForbiddenException and returns a FHIR-compliant OperationOutcome resource
+ */
+@Catch(ForbiddenException)
+export class FhirForbiddenExceptionFilter implements ExceptionFilter {
+    
+    /**
+     * Catches ForbiddenException and converts it to a FHIR OperationOutcome response
+     * @param exception - The ForbiddenException that was thrown
+     * @param host - The execution context containing the response object
+     */
+    catch(exception: ForbiddenException, host: ArgumentsHost): void {
+
+        const ctx = host.switchToHttp();
+        const response = ctx.getResponse<Response>();
+        
+        const fhirOutcome = FhirResponse.forbidden(exception.message);
+        
+        response
+            .status(403)
+            .json(fhirOutcome);
+    }
+}

--- a/src/lib/fhir-response.ts
+++ b/src/lib/fhir-response.ts
@@ -22,6 +22,17 @@ export class FhirResponse {
         }
     }
 
+    static forbidden(description: string): object {
+        return {
+            resourceType: 'OperationOutcome',
+            issue: [{
+                severity: 'error',
+                code: 'forbidden',
+                details: { text: description }
+            }]
+        }
+    }
+
     /**
      * Creates an OperationOutcome resource for invalid FHIR resources.
      * @param result - The validation result containing errors

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import helmet from 'helmet';
 import {FsLoggerService} from "./services/logger/fs-logger.service";
+import { FhirForbiddenExceptionFilter } from './filters/fhir-forbidden-exception.filter';
 
 async function bootstrap(): Promise<void> {
   
@@ -14,6 +15,8 @@ async function bootstrap(): Promise<void> {
   
   app.use(helmet());
   app.useStaticAssets(join(__dirname, "..", "static"));
+  
+  app.useGlobalFilters(new FhirForbiddenExceptionFilter());
   
   const config = new DocumentBuilder()
   .setTitle("Fhir Server API")


### PR DESCRIPTION
- Add FhirResponse.forbidden() method to create OperationOutcome for 403 errors
- Create FhirForbiddenExceptionFilter to catch and transform ForbiddenException
- Apply filter globally to ensure all security violations return FHIR-compliant responses
- Add comprehensive test coverage for the exception filter

🤖 Generated with [Claude Code](https://claude.ai/code)