### PR TITLE
fix: Correct metadata retrieval and clean up minor inconsistencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ NUL
 backup/
 *.bson
 *.metadata.json
+/.mcp.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.16.1](https://github.com/martijn-on-fhir/fhir-server/compare/v0.16.0...v0.16.1) (2025-09-14)
+
+
+### Bug Fixes
+
+* Correct metadata retrieval and clean up minor inconsistencies ([732f933](https://github.com/martijn-on-fhir/fhir-server/commit/732f9337d07ee37d5f7212d8b17147a954829eb3))
+* Correct test assertion for getMetaData distinct call ([81fd976](https://github.com/martijn-on-fhir/fhir-server/commit/81fd976f8e2f853b1716260a0a327348c91ba4f1))
+
 # [0.16.0](https://github.com/martijn-on-fhir/fhir-server/compare/v0.15.0...v0.16.0) (2025-09-08)
 
 # [0.15.0](https://github.com/martijn-on-fhir/fhir-server/compare/v0.14.1...v0.15.0) (2025-09-08)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fhir-server",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fhir-server",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@nestjs/cache-manager": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "start:prod": "node dist/main",
     "export:resource": "npx ts-node cli/export.ts",
     "import:resource": "npx ts-node cli/import.js",
+    "setup:dutch-profiles": "npx ts-node cli/setup-dutch-profiles.ts",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-server",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Enterprise-ready FHIR R4 server built with NestJS, featuring comprehensive resource validation, terminology services, subscription support, IP whitelisting, automated backups, and scalable MongoDB storage for healthcare interoperability",
   "author": "Martijn Schimmel",
   "private": false,

--- a/src/fhir/fhir.controller.ts
+++ b/src/fhir/fhir.controller.ts
@@ -50,7 +50,7 @@ export class FhirController {
   @ApiParam({ name: 'resourceType', description: 'Type of FHIR resource' })
   @Get(':resourceType')
   async searchResources(@Param('resourceType') resourceType: string, @Query() searchParams?: SearchParameters): Promise<SearchResult> {
-    return await this._service.find(resourceType, searchParams ?? {});
+      return await this._service.find(resourceType, searchParams ?? {});
   }
   
   @ApiOperation({ summary: 'Get FHIR resource by ID', description: 'Retrieve a specific FHIR resource by its type and ID' })
@@ -59,6 +59,7 @@ export class FhirController {
   @Get(':resourceType/:id')
   async getResource(@Param('resourceType') resourceType: string, @Param('id') id: string,
                     @Query() searchParams?: SearchParameters): Promise<any> {
+
     return await this._service.findById(resourceType, id, searchParams);
   }
   
@@ -66,7 +67,7 @@ export class FhirController {
   @ApiParam({ name: 'resourceType', description: 'Type of FHIR resource' })
   @Post(':resourceType')
   async createResource(@Param('resourceType') resourceType: string, @Body() resource: CreateResourceDto): Promise<any> {
-    
+
     await this._service.checkPreRequest('POST', resourceType, resource)
     return await this._service.create(resourceType, resource);
   }

--- a/src/services/fhir/fhir.service.spec.ts
+++ b/src/services/fhir/fhir.service.spec.ts
@@ -364,7 +364,7 @@ describe('FhirService', () => {
       const result = await service.getMetaData();
 
       expect(result).toEqual(mockMetadata);
-      expect(mockStructureDefinitionModel.distinct).toHaveBeenCalledWith('resourceType');
+      expect(mockStructureDefinitionModel.distinct).toHaveBeenCalledWith('type');
       expect(mockMetadataInstance.get).toHaveBeenCalledWith(['Patient', 'Observation']);
     });
   });

--- a/src/services/fhir/fhir.service.ts
+++ b/src/services/fhir/fhir.service.ts
@@ -258,7 +258,7 @@ export class FhirService {
      */
     public async getMetaData(): Promise<any> {
 
-        const structures = await this.structureDefinitonModel.distinct('resourceType').exec()
+        const structures = await this.structureDefinitonModel.distinct('type').exec()
         return (new Metadata()).get(structures)
     }
 


### PR DESCRIPTION
- Update `getMetaData` to use `type` instead of `resourceType` in structure definition query
- Add `.mcp.json` to `.gitignore` for development purposes
- Add `setup:dutch-profiles` script to `package.json` for profile configuration
- Minor formatting fixes across multiple files to ensure consistent code style